### PR TITLE
Memory and thread safety improved

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ FIND_PACKAGE(SQLite3 REQUIRED)
 INCLUDE_DIRECTORIES(./lib/include/)
 
 # add executables
-ADD_EXECUTABLE(SQLitePlusDemo src/main.cpp)
+ADD_EXECUTABLE(SQLitePlusDemo src/main.cpp lib/include/SQLITE3_QUERY.hpp lib/include/SQLITE3.hpp)
 
 # link libraries
 TARGET_LINK_LIBRARIES(SQLitePlusDemo LINK_PUBLIC ${SQLite3_LIBRARIES})

--- a/lib/include/SQLITE3.hpp
+++ b/lib/include/SQLITE3.hpp
@@ -273,9 +273,14 @@ public:
      *      (sqlite3_context* context, int argc, sqlite3_value** value)
      * @return 0 upon success, 1 upon failure
      */
-    int add_function(std::string name,int argc, void (*lambda)(sqlite3_context*, int, sqlite3_value**)){
+    int add_function(const std::string& name,int argc, void (*lambda)(sqlite3_context*, int, sqlite3_value**)){
         // add function to database
-        int rc = sqlite3_create_function(db, name.c_str(), argc, SQLITE_UTF8, NULL, lambda, NULL, NULL);
+        int rc = sqlite3_create_function(db, name.c_str(),
+                                         argc, SQLITE_UTF8,
+                                         nullptr,
+                                         lambda,
+                                         nullptr,
+                                         nullptr);
 
         // check success
         if (rc != SQLITE_OK) {

--- a/lib/include/SQLITE3.hpp
+++ b/lib/include/SQLITE3.hpp
@@ -209,9 +209,21 @@ public:
 
     /**
      * Return the result of a query
-     * @return std::vector<std::string>*
+     * @return shared pointer pointing to a copy of the result
      */
-    const std::vector<SQLITE_ROW_VECTOR>* get_result(){
+    std::shared_ptr<std::vector<SQLITE_ROW_VECTOR>> get_result_copy() {
+        auto ret = std::make_shared<std::vector<SQLITE_ROW_VECTOR>>();
+        std::copy(result->begin(), result->end(), std::back_inserter(*ret));
+        return ret;
+    }
+
+    /**
+     * @deprecated Deprecated due to possibility of unsafe memory access
+     *
+     * Return the result of a query
+     * @return pointer to
+     */
+    const std::vector<SQLITE_ROW_VECTOR>* get_result() {
         return result.get();
     }
 
@@ -219,7 +231,7 @@ public:
      * Print out result of statement
      */
     void print_result(){
-        for (auto &x : *get_result()){ // print results
+        for (auto &x : *result){ // print results
             std::cout << "|";
             for (auto &y : x){
                 std::cout << y << "|";

--- a/lib/include/SQLITE3.hpp
+++ b/lib/include/SQLITE3.hpp
@@ -323,9 +323,18 @@ public:
      */
     void print_result() {
         // copy result and column names
+        auto column_name_copy = copy_column_names();
         auto result_copy = copy_result();
 
-        for (SQLITE_ROW_VECTOR &row : *result_copy) { // print results
+        // print column names
+        std::cout << "|";
+        for (auto &name : *column_name_copy) {
+            std::cout << name << "|";
+        }
+        std::cout << std::endl;
+
+        // print rows
+        for (SQLITE_ROW_VECTOR &row : *result_copy) {
             std::cout << "|";
             for (auto &col : row) {
                 std::cout << col << "|";

--- a/lib/include/SQLITE3_QUERY.hpp
+++ b/lib/include/SQLITE3_QUERY.hpp
@@ -31,7 +31,7 @@ public:
      * constructor
      * @param query_template
      */
-     explicit SQLITE3_QUERY(std::string query_template = "") {
+    explicit SQLITE3_QUERY(std::string query_template = "") {
         this->query_template = std::move(query_template);
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,7 @@ int main() {
     std::cout << db.get_result_row_count() << " rows returned" << std::endl;
 
     // result is stored in a vector of SQLITE_ROW_VECTOR
-    auto result = db.get_result();
+    auto result = db.get_result_copy();
     std::cout << "The first element of first row is: " << result->at(0).at(0) << std::endl;
 
     // commit to save changes

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,11 +10,13 @@ int main() {
     std::cout << "test.db created" << std::endl;
     SQLITE3 db("test.db"); // init database
 
+
     // run execute plain string query
     if (db.execute("CREATE TABLE test (id int PRIMARY KEY, data text);")) {
         db.perror(); // in case of error, perror will print detail to stderr
     }
     std::cout << "Table test created" << std::endl;
+
 
     // run complex query using SQLITE3_QUERY object
     SQLITE3_QUERY query = SQLITE3_QUERY("INSERT INTO test VALUES (?, ?),(?, ?);"); // ? will be replaced after bind
@@ -29,6 +31,7 @@ int main() {
     }
     std::cout << "Repeated insertion failed" << std::endl;
 
+
     // methods from SQLITE3_QUERY can be chained, however, no chained function call can be after add_binding
     query.set_query_template("SELECT * FROM ?;").reset_binding().add_binding("test");
     if(!db.execute(query)){
@@ -37,16 +40,33 @@ int main() {
         db.perror();
     }
 
-    // get number of row returned
+
+    // get number of rows returned
     std::cout << db.get_result_row_count() << " rows returned" << std::endl;
 
+
+    // get number of cols returned
+    std::cout << db.get_result_col_count() << " cols returned" << std::endl;
+
+
+    // get column names
+    auto column_name = db.copy_column_names();
+    std::cout << "|";
+    for (auto &name : *column_name) {
+        std::cout << name << "|";
+    }
+    std::cout << std::endl;
+
+
     // result is stored in a vector of SQLITE_ROW_VECTOR
-    auto result = db.get_result_copy();
+    auto result = db.copy_result();
     std::cout << "The first element of first row is: " << result->at(0).at(0) << std::endl;
+
 
     // commit to save changes
     db.commit();
     std::cout << "Changes committed" << std::endl;
+
 
     // add user defined function to database
     db.add_function("PrintHello", //name of function
@@ -59,6 +79,7 @@ int main() {
     });
     db.execute("SELECT PrintHello(id) FROM TEST;");
     db.print_result();
+
 
     // drop table
     db.execute("DROP TABLE test;");


### PR DESCRIPTION
get_result deprecated and replaced with copy_result
all raw pointer replaced by shared_pointer
locking added to add thread safety
column name data capture added
print_result now print column names