### PR TITLE
feat: get_last_insert_rowid()

### DIFF
--- a/lib/include/SQLITE3.hpp
+++ b/lib/include/SQLITE3.hpp
@@ -329,6 +329,14 @@ public:
     }
 
     /**
+     * Get the last row id inserted
+     * @return last row id
+    */
+    int get_last_insert_rowid() const {
+        return sqlite3_last_insert_rowid(*db);
+    }
+
+    /**
      * Return the a copy of the column names for the result of the last query
      * @return shared pointer pointing to a copy of the column name
      */


### PR DESCRIPTION
I wrote a method that wraps sqlite3_last_insert_rowid() and returns the last inserted row id.